### PR TITLE
fix sr_id for geometry while updating record

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -9,21 +9,10 @@ class Builder extends EloquentBuilder
     {
         foreach ($values as $key => &$value) {
             if ($value instanceof GeometryInterface) {
-                $value = $this->asWKT($value);
+                $value = $this->getModel()->getPostgisValue($key, $value);
             }
         }
 
         return parent::update($values);
-    }
-
-    protected function getPostgisFields()
-    {
-        return $this->getModel()->getPostgisFields();
-    }
-
-
-    protected function asWKT(GeometryInterface $geometry)
-    {
-        return $this->getQuery()->raw(sprintf("public.ST_GeogFromText('%s')", $geometry->toWKT()));
     }
 }


### PR DESCRIPTION
Thanks for this awesome package. It is completely working fine when we create a record. But I got one minor error when we try to update a record. Actually, it's not getting proper sr_id in a query.

Here is the migration that I have created:

```
Schema::create('locations', function (Blueprint $table) {
    $table->increments('id');
    $table->string('name');
    $table->point('location', 'GEOMETRY', 27700);
    $table->timestamps();
});
```

This is my Model:

```
class Location extends Model
{
    use PostgisTrait;

    protected $fillable = [
        'name'
    ];

    protected $postgisFields = [
        'location'
    ];

    protected $postgisTypes = [
        'location' => [
            'geomtype' => 'geometry',
            'srid' => 27700
        ]
    ];
}
```

And this is how I'm creating and updating record.

```
$location = new \App\Location();
$location->name = "Location1";
$location->location = new Point(37.422009, -122.084047);;
$location->save();

$createdLocation = \App\Location::find($location->id);
$createdLocation->location = new Point(37.422009, -123.084047);
$createdLocation->save();

dd($createdLocation->toArray());
```
so while `save` function, I am getting following error:
```
SQLSTATE[42804]: Datatype mismatch: 7 ERROR:  column "location" is of type geometry but expression is of type geography
LINE 1: update "locations" set "location" = public.ST_GeogFromText('...
                                            ^
HINT:  You will need to rewrite or cast the expression. (SQL: update "locations" set "location" = public.ST_GeogFromText('POINT(-123.084047 37.422009)'), "updated_at" = 2017-09-16 14:03:47 where "id" = 1)
```