### PR TITLE
bind db.connection as well

### DIFF
--- a/src/DatabaseServiceProvider.php
+++ b/src/DatabaseServiceProvider.php
@@ -30,5 +30,8 @@ class DatabaseServiceProvider extends PostgresDatabaseServiceProvider
         $this->app->singleton('db', function ($app) {
             return new DatabaseManager($app, $app['db.factory']);
         });
+        $this->app->bind('db.connection', function ($app) {
+            return $app['db']->connection();
+        });
     }
 }


### PR DESCRIPTION
Original Laravel DatabaseServiceProvider binds the 'db.connection' service which is missing here.
```
 dd(app('db.connection'));
Illuminate\Database\PostgresConnection
```
What I don't understand is it seems to have work previously : https://github.com/njbarrett/laravel-postgis/issues/62