### PR TITLE
Correct order for lat/lng @ Geometries/Point::fromPair()

### DIFF
--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -69,8 +69,8 @@ class Point extends Geometry
     {
         $pair = preg_replace('/^[a-zA-Z\(\)]+/', '', trim($pair));
         $splits = explode(' ', trim($pair));
-        $lng = $splits[0];
-        $lat = $splits[1];
+        $lat = $splits[0];
+        $lng = $splits[1];
         if (count($splits) > 2) {
             $alt = $splits[2];
         }

--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -52,7 +52,7 @@ class Point extends Geometry
 
     public function toPair()
     {
-        $pair = self::stringifyFloat($this->getLng()) . ' ' . self::stringifyFloat($this->getLat());
+        $pair = self::stringifyFloat($this->getLat()) . ' ' . self::stringifyFloat($this->getLng());
         if ($this->is3d()) {
             $pair .= ' ' . self::stringifyFloat($this->getAlt());
         }


### PR DESCRIPTION
Lat/Long order was misplaced when you're creating a Point from a regular string pair (copy pasted from google maps)