### PR TITLE
Fix connecting to database when package is registered

### DIFF
--- a/src/Connectors/ConnectionFactory.php
+++ b/src/Connectors/ConnectionFactory.php
@@ -1,5 +1,6 @@
 <?php namespace MStaack\LaravelPostgis\Connectors;
 
+use Illuminate\Database\Connection;
 use PDO;
 use MStaack\LaravelPostgis\PostgisConnection;
 
@@ -15,8 +16,8 @@ class ConnectionFactory extends \Bosnadev\Database\Connectors\ConnectionFactory
      */
     protected function createConnection($driver, $connection, $database, $prefix = '', array $config = [])
     {
-        if ($this->container->bound($key = "db.connection.{$driver}")) {
-            return $this->container->make($key, [$connection, $database, $prefix, $config]);
+        if ($resolver = Connection::getResolver($driver)) {
+            return $resolver($connection, $database, $prefix, $config);
         }
 
         if ($driver === 'pgsql') {

--- a/src/PostgisConnection.php
+++ b/src/PostgisConnection.php
@@ -7,15 +7,6 @@ use MStaack\LaravelPostgis\Schema\Grammars\PostgisGrammar;
 
 class PostgisConnection extends PostgresConnection
 {
-    public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
-    {
-        parent::__construct($pdo, $database, $tablePrefix, $config);
-
-        // Prevent geography type fields from throwing a 'type not found' error.
-        $this->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('geography', 'string');
-        $this->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('geometry', 'string');
-    }
-
     /**
      * Get the default schema grammar instance.
      *


### PR DESCRIPTION
This remove unnecessary connection to database when package is registered. I modified `createConnection` to work the same as in upstream [ConnectionFactory.php](https://github.com/laravel/framework/blob/8f22cabf3e29cabb206eec01b7c856e993e54eb7/src/Illuminate/Database/Connectors/ConnectionFactory.php#L272) and I removed registering of Doctrine custom types, because it caused similar issue to https://github.com/laravel/framework/issues/28282. 

Is registering of Doctrine custom types really needed? For me it works without any issue. 