### PR TITLE
Add methods to enable / disable PostGIS only if relevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,57 @@ If you are using Laravel < 5.5, you also need to add the DatabaseServiceProvider
 ```
 ## Usage
 
-First of all, make sure to enable postgis.
+To start, ensure you have PostGIS enabled in your database - you can do this in a Laravel migration or manually via SQL.
+
+### Enable PostGIS via a Laravel migration
+
+Create a new migration file by running
+
+    php artisan make:migration enable_postgis
+
+Update the newly created migration file to call the `enablePostgisIfNotExists()` and `disablePostgisIfExists()` methods on the `Schema` facade. For example:
+
+```PHP
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class EnablePostgis extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::enablePostgisIfNotExists();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::disablePostgisIfExists();
+    }
+}
+```
+
+These methods are safe to use and will only enable / disable the PostGIS extension if relevant - they won't cause an error if PostGIS is / isn't already enabled.
+
+If you prefer, you can use the `enablePostgis()` method which will throw an error if PostGIS is already enabled, and the `disablePostgis()` method twhich will throw an error if PostGIS isn't enabled. 
+
+### Enable PostGIS manually
+
+Use an SQL client to connect to your database and run the following command:
 
     CREATE EXTENSION postgis;
 
-To verify that postgis is enabled
+To verify that PostGIS is enabled you can run:
 
     SELECT postgis_full_version();
 

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -148,4 +148,15 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
         return $this->addCommand('disablePostgis');
     }
 
+    /**
+     * Disable postgis on this database.
+     * WIll drop the extension in the database if it exists.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function disablePostgisIfExists()
+    {
+        return $this->addCommand('disablePostgisIfExists');
+    }
+
 }

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -127,8 +127,20 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
     }
 
     /**
+     * Enable postgis on this database.
+     * Will create the extension in the database if it doesn't already exist.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function enablePostgisIfNotExists()
+    {
+        return $this->addCommand('enablePostgisIfNotExists');
+    }
+
+    /**
      * Disable postgis on this database.
      * WIll drop the extension in the database.
+     *
      * @return \Illuminate\Support\Fluent
      */
     public function disablePostgis()

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -54,4 +54,17 @@ class Builder extends \Bosnadev\Database\Schema\Builder
             $this->grammar->compileDisablePostgis()
         );
     }
+
+    /**
+     * Disable postgis on this database.
+     * WIll drop the extension in the database if it exists.
+     *
+     * @return bool
+     */
+    public function disablePostgisIfExists()
+    {
+        return $this->connection->statement(
+            $this->grammar->compileDisablePostgisIfExists()
+        );
+    }
 }

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -17,7 +17,8 @@ class Builder extends \Bosnadev\Database\Schema\Builder
     }
 
     /**
-     * Enable foreign key constraints.
+     * Enable postgis on this database.
+     * Will create the extension in the database.
      *
      * @return bool
      */
@@ -29,7 +30,21 @@ class Builder extends \Bosnadev\Database\Schema\Builder
     }
 
     /**
-     * Disable foreign key constraints.
+     * Enable postgis on this database.
+     * Will create the extension in the database if it doesn't already exist.
+     *
+     * @return bool
+     */
+    public function enablePostgisIfNotExists()
+    {
+        return $this->connection->statement(
+            $this->grammar->compileEnablePostgisIfNotExists()
+        );
+    }
+
+    /**
+     * Disable postgis on this database.
+     * WIll drop the extension in the database.
      *
      * @return bool
      */

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -154,6 +154,16 @@ class PostgisGrammar extends PostgresGrammar
     }
 
     /**
+     * Adds a statement to drop the postgis extension, if it exists
+     *
+     * @return string
+     */
+    public function compileDisablePostgisIfExists()
+    {
+        return 'DROP EXTENSION IF EXISTS postgis';
+    }
+
+    /**
      * Adds a statement to add a geometry column
      *
      * @param Blueprint $blueprint

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -134,6 +134,16 @@ class PostgisGrammar extends PostgresGrammar
     }
 
     /**
+     * Adds a statement to create the postgis extension, if it doesn't already exist
+     *
+     * @return string
+     */
+    public function compileEnablePostgisIfNotExists()
+    {
+        return 'CREATE EXTENSION IF NOT EXISTS postgis';
+    }
+
+    /**
      * Adds a statement to drop the postgis extension
      *
      * @return string

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -90,6 +90,15 @@ class BlueprintTest extends BaseTestCase
         $this->blueprint->enablePostgis();
     }
 
+    public function testEnablePostgisIfNotExists()
+    {
+        $this->blueprint
+            ->shouldReceive('addCommand')
+            ->with('enablePostgis', []);
+
+        $this->blueprint->enablePostgisIfNotExists();
+    }
+
     public function testDisablePostgis()
     {
         $this->blueprint

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -107,4 +107,13 @@ class BlueprintTest extends BaseTestCase
 
         $this->blueprint->disablePostgis();
     }
+
+    public function testDisablePostgisIfExists()
+    {
+        $this->blueprint
+            ->shouldReceive('addCommand')
+            ->with('disablePostgis', []);
+
+        $this->blueprint->disablePostgisIfExists();
+    }
 }

--- a/tests/Schema/Grammars/PostgisGrammarTest.php
+++ b/tests/Schema/Grammars/PostgisGrammarTest.php
@@ -294,6 +294,16 @@ class PostgisGrammarTest extends BaseTestCase
         $this->assertStringContainsString('DROP EXTENSION postgis', $statements[0]);
     }
 
+    public function testDisablePostgisIfExists()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->disablePostgisIfExists();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);;
+        $this->assertStringContainsString('DROP EXTENSION IF EXISTS postgis', $statements[0]);
+    }
+
     /**
      * @return Connection
      */

--- a/tests/Schema/Grammars/PostgisGrammarTest.php
+++ b/tests/Schema/Grammars/PostgisGrammarTest.php
@@ -274,6 +274,16 @@ class PostgisGrammarTest extends BaseTestCase
         $this->assertStringContainsString('CREATE EXTENSION postgis', $statements[0]);
     }
 
+    public function testEnablePostgisIfNotExists()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->enablePostgisIfNotExists();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);;
+        $this->assertStringContainsString('CREATE EXTENSION IF NOT EXISTS postgis', $statements[0]);
+    }
+
     public function testDisablePostgis()
     {
         $blueprint = new Blueprint('test');


### PR DESCRIPTION
I noticed there are already methods for enabling (`enablePostgis()`) and disabling (`disablePostgis()`) PostGIS via a migration, but these throw an error if PostGIS is already enabled / disabled.

With the introduction of [parallel testing in Laravel 8.25](https://blog.laravel.com/laravel-parallel-testing-is-now-available) the framework may create a new database for tests - therefore the enabling of PostGIS needs to be in a migration.

While the existing `enablePostgis()` method would work on the first run of the test suite, it causes an error on subsequent runs as the PostGIS extension is already enabled in the database.

Whilst this could be solved by using the `--recreate-databases` flag on each run of this test suite, I think it would be better to add methods to this package to handle this through the use of `IF EXISTS` and `IF NOT EXISTS` parameters. They maybe useful for other use cases too.

This PR adds two new methods, `enablePostgisIfNotExists()` and `disablePostgisIfExists()` and the relevant tests.

I've also updated the README - it already had instructions for manually enabling PostGIS, so I've added to it to cover using the new & old methods (which were undocumented) in a migration.