### PR TITLE
Fixes MultiPoint::fromWKT() so it works with alternate no nested parenthesis wkt

### DIFF
--- a/src/Geometries/MultiPoint.php
+++ b/src/Geometries/MultiPoint.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace MStaack\LaravelPostgis\Geometries;
+use InvalidArgumentException;
 
 class MultiPoint extends PointCollection implements GeometryInterface, \JsonSerializable
 {

--- a/src/Geometries/MultiPoint.php
+++ b/src/Geometries/MultiPoint.php
@@ -43,6 +43,13 @@ class MultiPoint extends PointCollection implements GeometryInterface, \JsonSeri
 
     public static function fromString($wktArgument)
     {
+        if (!strpos(trim($wktArgument), '(')) {
+            $points = explode(',', $wktArgument);
+            $wktArgument = implode(", ", array_map(function ($pair) {
+                return '(' . trim($pair) . ')';
+            }, $points));
+        };
+
         $matches = [];
         preg_match_all('/\(\s*(\d+\s+\d+(\s+\d+)?)\s*\)/', trim($wktArgument), $matches);
 

--- a/src/Geometries/MultiPoint.php
+++ b/src/Geometries/MultiPoint.php
@@ -45,13 +45,13 @@ class MultiPoint extends PointCollection implements GeometryInterface, \JsonSeri
     {
         if (!strpos(trim($wktArgument), '(')) {
             $points = explode(',', $wktArgument);
-            $wktArgument = implode(", ", array_map(function ($pair) {
+            $wktArgument = implode(',', array_map(function ($pair) {
                 return '(' . trim($pair) . ')';
             }, $points));
         };
 
         $matches = [];
-        preg_match_all('/\(\s*(\d+\s+\d+(\s+\d+)?)\s*\)/', trim($wktArgument), $matches);
+        preg_match_all('/\(\s*([+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)+\s+[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)+(\s+[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)+)?)\s*\)/', trim($wktArgument), $matches);
 
         if (count($matches) < 2) {
             return new static([]);

--- a/tests/Geometries/MultiPointTest.php
+++ b/tests/Geometries/MultiPointTest.php
@@ -16,6 +16,14 @@ class MultiPointTest extends BaseTestCase
         $this->assertEquals(3, $multipoint->count());
     }
 
+    public function testFromWKTWithFloatingPoint()
+    {
+        $multipoint = MultiPoint::fromWKT('MULTIPOINT((1.0 1.0),(2.0 1.0),(2.0 2.0))');
+        $this->assertInstanceOf(MultiPoint::class, $multipoint);
+
+        $this->assertEquals(3, $multipoint->count());
+    }
+
     public function testFromWKTWithoutNestedParentesis()
     {
         $multipoint = MultiPoint::fromWKT('MULTIPOINT(1 1, 2 1, 2 2)');

--- a/tests/Geometries/MultiPointTest.php
+++ b/tests/Geometries/MultiPointTest.php
@@ -32,6 +32,14 @@ class MultiPointTest extends BaseTestCase
         $this->assertEquals(3, $multipoint->count());
     }
 
+    public function testFromWKT3dWithoutNestedParentesis()
+    {
+        $multipoint = MultiPoint::fromWKT('MULTIPOINT Z(1 1 1, 2 1 3, 2 2 2)');
+        $this->assertInstanceOf(MultiPoint::class, $multipoint);
+
+        $this->assertEquals(3, $multipoint->count());
+    }
+
     public function testToWKT()
     {
         $collection = [new Point(1, 1), new Point(1, 2), new Point(2, 2)];

--- a/tests/Geometries/MultiPointTest.php
+++ b/tests/Geometries/MultiPointTest.php
@@ -16,6 +16,14 @@ class MultiPointTest extends BaseTestCase
         $this->assertEquals(3, $multipoint->count());
     }
 
+    public function testFromWKTWithoutInnerParentesis()
+    {
+        $multipoint = MultiPoint::fromWKT('MULTIPOINT(1 1, 2 1, 2 2)');
+        $this->assertInstanceOf(MultiPoint::class, $multipoint);
+
+        $this->assertEquals(3, $multipoint->count());
+    }
+
     public function testFromWKT3d()
     {
         $multipoint = MultiPoint::fromWKT('MULTIPOINT Z((1 1 1),(2 1 3),(2 2 2))');

--- a/tests/Geometries/MultiPointTest.php
+++ b/tests/Geometries/MultiPointTest.php
@@ -16,7 +16,7 @@ class MultiPointTest extends BaseTestCase
         $this->assertEquals(3, $multipoint->count());
     }
 
-    public function testFromWKTWithoutInnerParentesis()
+    public function testFromWKTWithoutNestedParentesis()
     {
         $multipoint = MultiPoint::fromWKT('MULTIPOINT(1 1, 2 1, 2 2)');
         $this->assertInstanceOf(MultiPoint::class, $multipoint);


### PR DESCRIPTION
Sorry for not discussing this problem before doing the PR :(

WKT officially supports two syntaxes for MultiPoint, one with nested parenthesis and one without:

MULTIPOINT ((10 40), (40 30), (20 20), (30 10))
MULTIPOINT (10 40, 40 30, 20 20, 30 10)

[https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)

laravel-postgis only supports the nested parenthesis syntax.
Postgis st_astext unfortunately uses the version without nested parenthesis:

`select st_astext(st_geomfromtext('MULTIPOINT((1 1),(2 1),(2 2))'))`
would return 
`MULTIPOINT(1 1,2 1,2 2)`

This PR fixes the problem by checking if no nested parenthesis syntax is used, and if so, adding the parenthesis and go on with the rest of the function. This could probably be done in a more elegant way but I'm not that good at regex :( There is a test proving this problem in the PR.

The PR also updates the regex to support floating point values, it replaces \d by [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+) as explained here: [https://stackoverflow.com/questions/12643009/regular-expression-for-floating-point-numbers](https://stackoverflow.com/questions/12643009/regular-expression-for-floating-point-numbers) but yet again, I'm far from an expert with regular expressions. There is also a test proving the problem.


Thanks for maintaining this great package!

