### PR TITLE
Add publishable migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,45 +54,21 @@ To start, ensure you have PostGIS enabled in your database - you can do this in 
 
 ### Enable PostGIS via a Laravel migration
 
-Create a new migration file by running
+You need to publish the migration to easily enable PostGIS:
 
-    php artisan make:migration enable_postgis
+```sh
+php artisan vendor:publish --provider="MStaack\LaravelPostgis\DatabaseServiceProvider" --tag="migrations"
+```
 
-Update the newly created migration file to call the `enablePostgisIfNotExists()` and `disablePostgisIfExists()` methods on the `Schema` facade. For example:
+And then you run the migrations:
 
-```PHP
-<?php
-
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\Schema;
-
-class EnablePostgis extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
-        Schema::enablePostgisIfNotExists();
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::disablePostgisIfExists();
-    }
-}
+```sh
+php artisan migrate
 ```
 
 These methods are safe to use and will only enable / disable the PostGIS extension if relevant - they won't cause an error if PostGIS is / isn't already enabled.
 
-If you prefer, you can use the `enablePostgis()` method which will throw an error if PostGIS is already enabled, and the `disablePostgis()` method twhich will throw an error if PostGIS isn't enabled. 
+If you prefer, you can use the `enablePostgis()` method which will throw an error if PostGIS is already enabled, and the `disablePostgis()` method twhich will throw an error if PostGIS isn't enabled.
 
 ### Enable PostGIS manually
 

--- a/database/migrations/enable_postgis.php.stub
+++ b/database/migrations/enable_postgis.php.stub
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class EnablePostgis extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::enablePostgisIfNotExists();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::disablePostgisIfExists();
+    }
+}

--- a/src/DatabaseServiceProvider.php
+++ b/src/DatabaseServiceProvider.php
@@ -13,6 +13,13 @@ class DatabaseServiceProvider extends PostgresDatabaseServiceProvider
         // Load the config
         $config_path = __DIR__ . '/../config/postgis.php';
         $this->publishes([$config_path => config_path('postgis.php')], 'postgis');
+
+        if (!class_exists('EnablePostgis')) {
+            $this->publishes([
+                __DIR__ . '/../database/migrations/enable_postgis.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_enable_postgis.php'),
+            ], 'migrations');
+        }
+
         $this->mergeConfigFrom($config_path, 'postgis');
     }
 


### PR DESCRIPTION
#152 added methods to enable and disable PostGIS only if it exists.

This PR removes the need manually create a migration file by already defining it as publishable migration. So all you have to do now is:

```sh
php artisan vendor:publish --provider="MStaack\LaravelPostgis\DatabaseServiceProvider" --tag="migrations"
```

And then you run:

```sh
php artisan migrate
```

And voilá you're done. :)

I also updated the README.md to reflect the easier setup.