### PR TITLE
Add Laravel 9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $table->polygon('myColumn');
 ```
 
 ## Warning
-This Package has been moved to a new owner and aims for Laravel 6/7/8  and PHP 7 support only soon!
+This Package has been moved to a new owner and aims for Laravel 6/7/8/9  and PHP 7 support only soon!
 
 Replace all your references to the new namespace:
 ```
@@ -37,7 +37,7 @@ Fluent in Laravel Packages and Postgres/Postgis? Consider contributing! We are l
 composer require "mstaack/laravel-postgis:3.*"
 ```
 
-- Use 5.* for Laravel 6/7/8
+- Use 5.* for Laravel 6/7/8/9
 ```bash
 composer require mstaack/laravel-postgis
 ```

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
   "description": "Postgis extensions for laravel. Aims to make it easy to work with geometries from laravel models",
   "require": {
     "php": ">=7.1",
-    "illuminate/database": "^6.0|^7.0|^8.0",
+    "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
     "geo-io/wkb-parser": "^1.0",
     "jmikola/geojson": "^1.0",
     "bosnadev/database": "^0.21"
   },
   "require-dev": {
-    "illuminate/pagination": "^6.0|^7.0|^8.0",
+    "illuminate/pagination": "^6.0|^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^8.5",
     "mockery/mockery": "^1.3"
   },


### PR DESCRIPTION
Laravel 9 [is due](https://laravel.com/docs/8.x/releases#support-policy) for release on February 8th.

I've had a look through the [upgrade guide](https://laravel.com/docs/master/upgrade) _(in its current state - obviously won't be finalised until the release)_ and **I don't think** there are any breaking changes that will cause problems in this package.

Therefore this PR simply adds `^9.0` to the version constraints in `composer.json` for the `illuminate/*` dependencies.

We'll also need the `bosnadev/database` dependency to add `^9.0` support, so [I've opened a similar PR there](https://github.com/bosnadev/database/pull/52).
