### PR TITLE
Update jsonSerialize return type

### DIFF
--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -100,7 +100,7 @@ class Point extends Geometry
      *
      * @return \GeoJson\Geometry\Point
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $position = [$this->getLng(), $this->getLat()];
         if ($this->is3d()) $position[] = $this->getAlt();


### PR DESCRIPTION
Return type of Point jsonSerialize needs updating because:

 > PHP Deprecated:  Return type of MStaack\LaravelPostgis\Geometries\Point::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/anders/Code/propertysearch/vendor/mstaack/laravel-postgis/src/Geometries/Point.php on line 103

Fixes #162

Let me know if this is good I can do the other types as well.