### PR TITLE
Add linestringz

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -69,6 +69,17 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
     }
 
     /**
+     * Add a linestringz column on the table
+     *
+     * @param      $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function linestringz($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
+    {
+        return $this->addColumn('linestringz', $column, compact('geomtype', 'srid'));
+    }
+
+    /**
      * Add a multilinestring column on the table
      *
      * @param      $column

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -77,6 +77,17 @@ class PostgisGrammar extends PostgresGrammar
     }
 
     /**
+     * Adds a statement to add a linestringz geometry column
+     *
+     * @param \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    public function typeLinestringZ(Fluent $column)
+    {
+        return $this->createTypeDefinition($column, 'LINESTRINGZ');
+    }
+
+    /**
      * Adds a statement to add a multilinestring geometry column
      *
      * @param \Illuminate\Support\Fluent $column


### PR DESCRIPTION
Linestring with a z dimension is already supported, this addition enables the column type to be added in a migration as well:
```php
$table->linestringz('path');
```