### PR TITLE
Add linestringz and pointz

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -14,6 +14,17 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
     }
 
     /**
+     * Add a point column on the table
+     *
+     * @param      $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function pointz($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
+    {
+        return $this->addColumn('pointz', $column, compact('geomtype', 'srid'));
+    }
+
+    /**
      * Add a multipoint column on the table
      *
      * @param      $column

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -69,6 +69,17 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
     }
 
     /**
+     * Add a linestringz column on the table
+     *
+     * @param      $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function linestringz($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
+    {
+        return $this->addColumn('linestringz', $column, compact('geomtype', 'srid'));
+    }
+
+    /**
      * Add a multilinestring column on the table
      *
      * @param      $column

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -22,6 +22,17 @@ class PostgisGrammar extends PostgresGrammar
     }
 
     /**
+     * Adds a statement to add a pointz geometry column
+     *
+     * @param \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    public function typePointZ(Fluent $column)
+    {
+        return $this->createTypeDefinition($column, 'POINTZ');
+    }
+
+    /**
      * Adds a statement to add a point geometry column
      *
      * @param \Illuminate\Support\Fluent $column

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -77,6 +77,17 @@ class PostgisGrammar extends PostgresGrammar
     }
 
     /**
+     * Adds a statement to add a linestringz geometry column
+     *
+     * @param \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    public function typeLinestringZ(Fluent $column)
+    {
+        return $this->createTypeDefinition($column, 'LINESTRINGZ');
+    }
+
+    /**
      * Adds a statement to add a multilinestring geometry column
      *
      * @param \Illuminate\Support\Fluent $column


### PR DESCRIPTION
Linestring and points with z dimensions are already supported, this enables the column types to be added in a migration as well:
```php
$table->pointz('location');
$table->linestringz('path');
```