### PR TITLE
Fix coordinate precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,22 @@ Available geometry classes:
  * Polygon
  * MultiPolygon
  * GeometryCollection
+
+## Publishing config
+A configuration file exists for overriding default values. To add to your project, run:
+
+```sh
+php artisan vendor:publish --provider="MStaack\LaravelPostgis\DatabaseServiceProvider" --tag="postgis"
+```
+### Coordinate precision
+The precision of stored/displayed coordinated can be customised in the config.
+
+
+```php
+# config/postgis.php
+return [
+    ...
+    'precision' => 6,
+];
+```
+See http://wiki.gis.com/wiki/index.php/Decimal_degrees#Accuracy for more information

--- a/config/postgis.php
+++ b/config/postgis.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'schema' => 'public'  // Schema for the Postgis extension
+    'schema' => 'public',  // Schema for the Postgis extension,
+    'precision' => 6, // Control precision of floats in stringifyFloat
 ];

--- a/tests/Geometries/PointTest.php
+++ b/tests/Geometries/PointTest.php
@@ -126,4 +126,20 @@ class PointTest extends BaseTestCase
         $this->assertInstanceOf(\GeoJson\Geometry\Point::class, $point->jsonSerialize());
         $this->assertSame('{"type":"Point","coordinates":[3.4,1.2,5.6]}', json_encode($point));
     }
+
+    public function testPointPrecisionDefault()
+    {
+        $point = new Point(-37.8745505,144.9102885,12.38);
+
+        $this->assertSame('144.910289 -37.87455 12.38', $point->toPair());
+
+    }
+
+    public function testPointPrecision10()
+    {
+        $point = new Point(-37.87455051578,144.91028850798,7.38257341563);
+        $point->setPrecision(10);
+
+        $this->assertSame('144.910288508 -37.8745505158 7.3825734156', $point->toPair());
+    }
 }


### PR DESCRIPTION
PR to address  Coordinate precision lost #167 

Constructor reads value from config or defaults to 6 (the default precision for sprintf). It is not anticipated that users will want to customise precision for an individual point, so no argument has been added to the constructor signature.

A setter is provided for the precision property, though this is primarily to enable tests. If users do need to set precision for an individual point, the setter may be used.

stringifyFloat has been converted to dynamic function to ease testing. It was only ever called from a non-static context anyway.

Added tests, default config and updated readme