### PR TITLE
Add return type for PHP 8.1

### DIFF
--- a/src/Geometries/GeometryCollection.php
+++ b/src/Geometries/GeometryCollection.php
@@ -69,7 +69,7 @@ class GeometryCollection extends Geometry implements Countable
         );
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->geometries);
     }
@@ -79,7 +79,7 @@ class GeometryCollection extends Geometry implements Countable
      *
      * @return \GeoJson\Geometry\GeometryCollection
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \GeoJson\Geometry\GeometryCollection
     {
         $geometries = [];
         foreach ($this->geometries as $geometry) {

--- a/src/Geometries/LineString.php
+++ b/src/Geometries/LineString.php
@@ -44,7 +44,7 @@ class LineString extends PointCollection implements GeometryInterface
      *
      * @return \GeoJson\Geometry\LineString
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \GeoJson\Geometry\LineString
     {
         $points = [];
         foreach ($this->points as $point) {

--- a/src/Geometries/LineStringCollection.php
+++ b/src/Geometries/LineStringCollection.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MStaack\LaravelPostgis\Geometries;
+
+use Countable;
+use InvalidArgumentException;
+
+abstract class LineStringCollection extends Geometry implements Countable
+{
+    /**
+     * @var LineString[]
+     */
+    protected $linestrings = [];
+
+    /**
+     * @param LineString[] $linestrings
+     */
+    public function __construct(array $linestrings)
+    {
+        if (count($linestrings) < 1) {
+            throw new InvalidArgumentException('$linestrings must contain at least one entry');
+        }
+
+        $validated = array_filter($linestrings, function ($value) {
+            return $value instanceof LineString;
+        });
+
+        if (count($linestrings) !== count($validated)) {
+            throw new InvalidArgumentException('$linestrings must be an array of Points');
+        }
+
+        $this->linestrings = $linestrings;
+    }
+
+    public function getLineStrings()
+    {
+        return $this->linestrings;
+    }
+
+    public function is3d()
+    {
+        if (count($this->linestrings) === 0) return false;
+        return $this->linestrings[0]->is3d();
+    }
+
+    public static function fromString($wktArgument)
+    {
+        $str = preg_split('/\)\s*,\s*\(/', substr(trim($wktArgument), 1, -1));
+        $linestrings = array_map(function ($data) {
+            return LineString::fromString($data);
+        }, $str);
+
+
+        return new static($linestrings);
+    }
+
+    public function __toString()
+    {
+        return implode(',', array_map(function (LineString $linestring) {
+            return sprintf('(%s)', (string)$linestring);
+        }, $this->getLineStrings()));
+    }
+
+    public function count(): int
+    {
+        return count($this->linestrings);
+    }
+}

--- a/src/Geometries/MultiLineString.php
+++ b/src/Geometries/MultiLineString.php
@@ -68,7 +68,7 @@ class MultiLineString extends Geometry implements Countable
         }, $this->getLineStrings()));
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->linestrings);
     }

--- a/src/Geometries/MultiLineString.php
+++ b/src/Geometries/MultiLineString.php
@@ -2,47 +2,8 @@
 
 namespace MStaack\LaravelPostgis\Geometries;
 
-use Countable;
-use InvalidArgumentException;
-
-class MultiLineString extends Geometry implements Countable
+class MultiLineString extends LineStringCollection
 {
-    /**
-     * @var LineString[]
-     */
-    protected $linestrings = [];
-
-    /**
-     * @param LineString[] $linestrings
-     */
-    public function __construct(array $linestrings)
-    {
-        if (count($linestrings) < 1) {
-            throw new InvalidArgumentException('$linestrings must contain at least one entry');
-        }
-
-        $validated = array_filter($linestrings, function ($value) {
-            return $value instanceof LineString;
-        });
-
-        if (count($linestrings) !== count($validated)) {
-            throw new InvalidArgumentException('$linestrings must be an array of Points');
-        }
-
-        $this->linestrings = $linestrings;
-    }
-
-    public function getLineStrings()
-    {
-        return $this->linestrings;
-    }
-
-    public function is3d()
-    {
-        if (count($this->linestrings) === 0) return false;
-        return $this->linestrings[0]->is3d();
-    }
-
     public function toWKT()
     {
         $wktType = 'MULTILINESTRING';
@@ -50,35 +11,12 @@ class MultiLineString extends Geometry implements Countable
         return sprintf('%s(%s)', $wktType, (string)$this);
     }
 
-    public static function fromString($wktArgument)
-    {
-        $str = preg_split('/\)\s*,\s*\(/', substr(trim($wktArgument), 1, -1));
-        $linestrings = array_map(function ($data) {
-            return LineString::fromString($data);
-        }, $str);
-
-
-        return new static($linestrings);
-    }
-
-    public function __toString()
-    {
-        return implode(',', array_map(function (LineString $linestring) {
-            return sprintf('(%s)', (string)$linestring);
-        }, $this->getLineStrings()));
-    }
-
-    public function count(): int
-    {
-        return count($this->linestrings);
-    }
-
     /**
      * Convert to GeoJson Point that is jsonable to GeoJSON
      *
      * @return \GeoJson\Geometry\MultiLineString
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \GeoJson\Geometry\MultiLineString
     {
         $linestrings = [];
 

--- a/src/Geometries/MultiPoint.php
+++ b/src/Geometries/MultiPoint.php
@@ -77,7 +77,7 @@ class MultiPoint extends PointCollection implements GeometryInterface, \JsonSeri
      *
      * @return \GeoJson\Geometry\MultiPoint
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \GeoJson\Geometry\MultiPoint
     {
         $points = [];
         foreach ($this->points as $point) {

--- a/src/Geometries/MultiPolygon.php
+++ b/src/Geometries/MultiPolygon.php
@@ -67,7 +67,7 @@ class MultiPolygon extends Geometry implements Countable
      *       <p>
      *       The return value is cast to an integer.
      */
-    public function count()
+    public function count(): int
     {
         return count($this->polygons);
     }
@@ -121,7 +121,7 @@ class MultiPolygon extends Geometry implements Countable
      *
      * @return \GeoJson\Geometry\MultiPolygon
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \GeoJson\Geometry\MultiPolygon
     {
         $polygons = [];
         foreach ($this->polygons as $polygon) {

--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -115,7 +115,7 @@ class Point extends Geometry
      *
      * @return \GeoJson\Geometry\Point
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \GeoJson\Geometry\Point
     {
         $position = [$this->getLng(), $this->getLat()];
         if ($this->is3d()) $position[] = $this->getAlt();

--- a/src/Geometries/PointCollection.php
+++ b/src/Geometries/PointCollection.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use JsonSerializable;
+use Traversable;
 
 abstract class PointCollection implements IteratorAggregate, Arrayable, ArrayAccess, Countable, JsonSerializable
 {
@@ -46,7 +47,7 @@ abstract class PointCollection implements IteratorAggregate, Arrayable, ArrayAcc
         return $this->points;
     }
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->points);
     }
@@ -70,7 +71,7 @@ abstract class PointCollection implements IteratorAggregate, Arrayable, ArrayAcc
         array_splice($this->points, $offset, 0, [$point]);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->points[$offset]);
     }
@@ -79,12 +80,12 @@ abstract class PointCollection implements IteratorAggregate, Arrayable, ArrayAcc
      * @param mixed $offset
      * @return null|Point
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): ?Point
     {
         return $this->offsetExists($offset) ? $this->points[$offset] : null;
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (!($value instanceof Point)) {
             throw new InvalidArgumentException('$value must be an instance of Point');
@@ -97,12 +98,12 @@ abstract class PointCollection implements IteratorAggregate, Arrayable, ArrayAcc
         }
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->points[$offset]);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->points);
     }

--- a/src/Geometries/Polygon.php
+++ b/src/Geometries/Polygon.php
@@ -4,14 +4,8 @@ namespace MStaack\LaravelPostgis\Geometries;
 
 use GeoJson\Geometry\LinearRing;
 
-class Polygon extends MultiLineString
+class Polygon extends LineStringCollection
 {
-    public function is3d()
-    {
-        if (count($this->linestrings) === 0) return false;
-        return $this->linestrings[0]->is3d();
-    }
-
     public function toWKT()
     {
         $wktType = 'POLYGON';
@@ -24,7 +18,7 @@ class Polygon extends MultiLineString
      *
      * @return \GeoJson\Geometry\Polygon
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \GeoJson\Geometry\Polygon
     {
         $linearrings = [];
         foreach ($this->linestrings as $linestring) {


### PR DESCRIPTION
In PHP 8.1, PHP internal classes were updated with tentative return types. 
So I added return types to prevent the following types of warnings.

```
Deprecated: Return type of MStaack\LaravelPostgis\Geometries\GeometryCollection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /work/laravel-postgis/src/Geometries/GeometryCollection.php on line 72
```